### PR TITLE
Dec 2016 upgrades

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "wpackagist-plugin/transients-manager": "1.7.3",
         "wpackagist-plugin/user-switching": "1.0.9",
         "wpackagist-plugin/wordpress-seo": "4.0.2",
-        "roots/soil": "3.7.1"
+        "roots/soil": "3.7.1",
+        "Upstatement/routes": "*"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "wpackagist-plugin/user-switching": "1.0.9",
         "wpackagist-plugin/wordpress-seo": "4.0.2",
         "roots/soil": "3.7.1",
-        "Upstatement/routes": "*"
+        "upstatement/routes": "*"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
     "name": "patronage/bubs-wp",
+    "config": {
+        "vendor-dir": "wp-content/plugins/composer-libs"
+    },
     "require": {
         "php": ">=5.4.0",
         "WordPress/WordPress": "*",
@@ -9,19 +12,19 @@
         "wpackagist-plugin/bottom-admin-bar": "1.3",
         "wpackagist-plugin/debug-bar": "0.8.4",
         "wpackagist-plugin/debug-bar-timber": "0.3",
-        "wpackagist-plugin/disable-emojis": "1.5.2",
-        "wpackagist-plugin/duplicate-post": "3.0.3",
+        "wpackagist-plugin/disable-emojis": "1.5.3",
+        "wpackagist-plugin/duplicate-post": "3.1.2",
         "wpackagist-plugin/enable-media-replace": "3.0.5",
-        "wpackagist-plugin/google-apps-login": "2.10.4",
+        "wpackagist-plugin/google-apps-login": "2.10.5",
         "wpackagist-plugin/post-type-archive-links": "1.3.1",
         "wpackagist-plugin/post-type-switcher": "3.0.0",
-        "wpackagist-plugin/query-monitor": "2.13.1",
+        "wpackagist-plugin/query-monitor": "2.13.2",
         "wpackagist-plugin/term-management-tools": "1.1.4",
-        "wpackagist-plugin/timber-library": "1.1.10",
+        "wpackagist-plugin/timber-library": "1.1.12",
         "wpackagist-plugin/transients-manager": "1.7.3",
         "wpackagist-plugin/user-switching": "1.0.9",
-        "wpackagist-plugin/wordpress-seo": "3.8.0",
-        "roots/soil": "3.6.2"
+        "wpackagist-plugin/wordpress-seo": "4.0.2",
+        "roots/soil": "3.7.1"
     },
     "repositories": [
         {
@@ -29,10 +32,10 @@
             "package": {
                 "name": "WordPress/WordPress",
                 "type": "webroot",
-                "version": "4.6.1",
+                "version": "4.7",
                 "dist": {
                     "type": "zip",
-                    "url": "https://github.com/WordPress/WordPress/archive/4.6.1.zip"
+                    "url": "https://github.com/WordPress/WordPress/archive/4.7.zip"
                 },
                 "require": {
                     "fancyguy/webroot-installer": "~1.1"
@@ -47,7 +50,7 @@
             "type": "package",
             "package": {
                 "name": "advanced-custom-fields/advanced-custom-fields-pro",
-                "version": "5.4.8",
+                "version": "5.5.3",
                 "type": "wordpress-plugin",
                 "dist": {
                     "type": "zip",

--- a/wp-content/themes/timber/functions.php
+++ b/wp-content/themes/timber/functions.php
@@ -1,5 +1,7 @@
 <?php
 
+    require_once(get_theme_root() . "/../plugins/composer-libs/autoload.php"); //Make composer installed php libraries available
+
     //
     // Load WP Config files
     //


### PR DESCRIPTION
This PR has _two_ changes to consider:

* It refreshes Wordpress to the latest core (4.7) as well as the current plugins listed in `composer.json`. 

* Additionally, it adds the [Upstatement routes](https://github.com/upstatement/routes) library [recommended](https://github.com/timber/timber/wiki/1.0-Upgrade-Guide#routes) to be used with Timber Library version 1+ for routing, going forward. The libraries get installed to the `wp-content/plugins/composer-libs/` directory and are available for use in php (as the autoloader [is active](https://github.com/patronage/bubs/blob/dec-2016-upgrades/wp-content/themes/timber/functions.php#L3)). This approach has the advantage of making other Composer friendly PHP libraries, like Routes, easy to add going forward.

