### PR TITLE
33 post comit

### DIFF
--- a/_build/post-install.sh
+++ b/_build/post-install.sh
@@ -1,21 +1,22 @@
 #!/usr/bin/env bash
 
 # remove unneeded things from default WP, then copy out
-rm -rf ../composer/wp-content/themes/twenty*
-rm -rf ../composer/wp-config-sample.php
-rm -rf ../composer/wp-content/plugins/hello.php
-cp -R ../composer/* ../.
+rm -rf composer/wp-content/themes/twenty*
+rm -rf composer/wp-config-sample.php
+rm -rf composer/wp-content/plugins/hello.php
+cp -R composer/* .
 
 # conditionally create files from the init dir if they don't exist (first run only)
-cp -n ../_init/wp-config-sample.php ../wp-config.php 2>/dev/null || :
-cp -n ../_init/wp-config-local-sample.php ../wp-config-local.php 2>/dev/null || :
-cp -n ../_init/gulpconfig.json ../gulpconfig.json 2>/dev/null || :
-cp -n ../_init/local-plugi/ns.php ../wp-content/mu-plugins/local-plugins.php 2>/dev/null || :
-mv ../_init/README.md ../README.md 2>/dev/null || :
-mv ../_init/post-merge ../.git/hooks/post-merge 2>/dev/null || :
+cp -n _init/wp-config-sample.php wp-config.php 2>/dev/null || :
+cp -n _init/wp-config-local-sample.php wp-config-local.php 2>/dev/null || :
+cp -n _init/gulpconfig.json gulpconfig.json 2>/dev/null || :
+cp -n _init/local-plugins.php wp-content/mu-plugins/local-plugins.php 2>/dev/null || :
+cp -n _init/post-merge .git/hooks/post-merge 2>/dev/null || :
+mv _init/README.md README.md 2>/dev/null || :
+
 
 # chmod tasks
-mkdir -p ../wp-content/uploads && chmod 755 ../wp-content/uploads
-mkdir -p ../wp-content/themes/timber/acf-json && chmod -R 755 ../wp-content/themes/timber/acf-json
-chmod +x deploy.sh
-chmod +x ../.git/hooks/post-merge
+mkdir -p wp-content/uploads && chmod 755 wp-content/uploads
+mkdir -p wp-content/themes/timber/acf-json && chmod -R 755 wp-content/themes/timber/acf-json
+chmod +x _build/deploy.sh
+chmod +x .git/hooks/post-merge

--- a/_build/post-install.sh
+++ b/_build/post-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # remove unneeded things from default WP, then copy out
 rm -rf ../composer/wp-content/themes/twenty*

--- a/_build/post-install.sh
+++ b/_build/post-install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# remove unneeded things from default WP, then copy out
+rm -rf ../composer/wp-content/themes/twenty*
+rm -rf ../composer/wp-config-sample.php
+rm -rf ../composer/wp-content/plugins/hello.php
+cp -R ../composer/* ../.
+
+# conditionally create files from the init dir if they don't exist (first run only)
+cp -n ../_init/wp-config-sample.php ../wp-config.php 2>/dev/null || :
+cp -n ../_init/wp-config-local-sample.php ../wp-config-local.php 2>/dev/null || :
+cp -n ../_init/gulpconfig.json ../gulpconfig.json 2>/dev/null || :
+cp -n ../_init/local-plugi/ns.php ../wp-content/mu-plugins/local-plugins.php 2>/dev/null || :
+mv ../_init/README.md ../README.md 2>/dev/null || :
+mv ../_init/post-merge ../.git/hooks/post-merge 2>/dev/null || :
+
+# chmod tasks
+mkdir -p ../wp-content/uploads && chmod 755 ../wp-content/uploads
+mkdir -p ../wp-content/themes/timber/acf-json && chmod -R 755 ../wp-content/themes/timber/acf-json
+chmod +x deploy.sh
+chmod +x ../.git/hooks/post-merge

--- a/_init/post-merge
+++ b/_init/post-merge
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# MIT © Sindre Sorhus - sindresorhus.com
+# https://gist.github.com/sindresorhus/7996717
+
+# git hook to run a command after `git pull` if a specified file was changed
+# Run `chmod +x post-merge` to make it executable then put it into `.git/hooks/`.
+
+changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+
+check_run() {
+    echo "$changed_files" | grep --quiet "$1" && eval "$2"
+}
+
+# `npm install` if package.json changed
+check_run package.json "npm install"
+
+# `bower install` if bower.json changed
+check_run bower.json "bower install"
+
+# `composer install` if composer.lock changed
+check_run composer.lock "composer install"
+
+# re-run chmod on  ACF to ensure files are editable
+chmod 755 -R wp-content/themes/timber/acf-json/*

--- a/composer.json
+++ b/composer.json
@@ -101,20 +101,7 @@
     },
     "scripts": {
         "post-install-cmd": [
-            "rm -rf composer/wp-content/themes/twenty*",
-            "rm -rf composer/wp-config-sample.php",
-            "rm -rf composer/wp-content/plugins/hello.php",
-            "cp -R composer/* .",
-
-            "cp -n _init/wp-config-sample.php wp-config.php 2>/dev/null || :",
-            "cp -n _init/wp-config-local-sample.php wp-config-local.php 2>/dev/null || :",
-            "cp -n _init/gulpconfig.json gulpconfig.json 2>/dev/null || :",
-            "cp -n _init/local-plugins.php wp-content/mu-plugins/local-plugins.php 2>/dev/null || :",
-            "mv _init/README.md README.md 2>/dev/null || :",
-
-            "mkdir -p wp-content/uploads && chmod 777 wp-content/uploads",
-            "mkdir -p wp-content/themes/timber/acf-json && chmod -R 777 wp-content/themes/timber/acf-json",
-            "chmod +x ./_build/deploy.sh"
+            "bash _build/post-install.sh"
         ]
     }
 }


### PR DESCRIPTION
@kylehotchkiss and @jeffgreco take a look at this.

The goal is twofold:

1) Have a post-commit hook that will apply our chmod changes more reliably, and also rerun bower/node/composer when their json files change.

2) Move the composer post-install tasks into it's own file for easier maintenance, and hopefully fix the issues jeff was having in #40.

@jeffgreco if you can try both `composer install`, and also `bash _build/post-install.sh`, I wonder if they behave the same way.