### PR TITLE
44 plain default mobile nav

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
     "tests"
   ],
   "dependencies": {
+    "bootstrap-hover-dropdown": "^2.2.1",
     "FitVids": "~1.1.0",
     "cookies-js": "~1.2.1",
     "jquery-placeholder": "~2.2.0",

--- a/wp-content/themes/timber/assets/js/main.js
+++ b/wp-content/themes/timber/assets/js/main.js
@@ -8,7 +8,7 @@ var fitVidInit = function(){
 };
 
 var smoothScrollInit = function(){
-    $('a.scroll').smoothScroll();
+    $('a').smoothScroll();
 };
 
 var matchHeightInit = function(){

--- a/wp-content/themes/timber/assets/js/main.js
+++ b/wp-content/themes/timber/assets/js/main.js
@@ -19,36 +19,11 @@ var quickShareInit = function(){
     quickShare();
 };
 
-var headerNavPosition = function(inMobileMq){
-    // in mobile, the middle images are under the second large image . in desktop they are under the first one
-    if ( inMobileMq.matches ){ // mobile
-        $('.main-header-nav-desktop-holder .main-header-nav').appendTo( $('.main-header-nav-mobile-holder') );
-    } else { //desktop
-        $('.main-header-nav-mobile-holder .main-header-nav').appendTo($('.main-header-nav-desktop-holder'));
-    }
-};
-
-var headerInit = function(){
-    mobileMq = window.matchMedia('(max-width: 767px)'); //are we in mobile?
-
-    //initial
-    headerNavPosition(mobileMq);
-
-    //on resize
-    mobileMq.addListener(function(mql){
-        headerNavPosition(mql);
-    });
-
-};
-
-// init without document.ready
-
 // init within document.ready
 (function($) {
 
     fitVidInit();
     matchHeightInit();
-    headerInit();
     smoothScrollInit();
     quickShareInit();
     analyticsSourcing();

--- a/wp-content/themes/timber/assets/js/main.js
+++ b/wp-content/themes/timber/assets/js/main.js
@@ -8,7 +8,7 @@ var fitVidInit = function(){
 };
 
 var smoothScrollInit = function(){
-    $('a').smoothScroll();
+    $('a.scroll').smoothScroll();
 };
 
 var matchHeightInit = function(){
@@ -19,6 +19,28 @@ var quickShareInit = function(){
     quickShare();
 };
 
+var headerNavPosition = function(inMobileMq){
+    // in mobile, the middle images are under the second large image . in desktop they are under the first one
+    if ( inMobileMq.matches ){ // mobile
+        $('.main-header-nav-desktop-holder .main-header-nav').appendTo( $('.main-header-nav-mobile-holder') );
+    } else { //desktop
+        $('.main-header-nav-mobile-holder .main-header-nav').appendTo($('.main-header-nav-desktop-holder'));
+    }
+};
+
+var headerInit = function(){
+    mobileMq = window.matchMedia('(max-width: 767px)'); //are we in mobile?
+
+    //initial
+    headerNavPosition(mobileMq);
+
+    //on resize
+    mobileMq.addListener(function(mql){
+        headerNavPosition(mql);
+    });
+
+};
+
 // init without document.ready
 
 // init within document.ready
@@ -26,6 +48,7 @@ var quickShareInit = function(){
 
     fitVidInit();
     matchHeightInit();
+    headerInit();
     smoothScrollInit();
     quickShareInit();
     analyticsSourcing();

--- a/wp-content/themes/timber/assets/scss/layouts/_header.scss
+++ b/wp-content/themes/timber/assets/scss/layouts/_header.scss
@@ -1,0 +1,95 @@
+.main-header {
+    .top-level-menu {
+        padding: 10px 0 5px;
+    }
+
+    ul {
+        list-style: none;
+    }
+
+    // '+' mobile dropdown toggle link so see submenus, instead of relying on hover
+    a.plus-expand {
+        margin: 0;
+        padding: 4px;
+        float: right;
+        width: auto;
+        position: relative;
+        top: -8px;
+
+        &:hover {
+            text-decoration: none;
+        }
+
+
+        i {
+            display: none;
+        }
+        &[href]{
+            visibility: visible;
+            i {
+                display: inline;
+            }
+        }
+        i {
+            font-size: 12px;
+        }
+    }
+
+    .main-header-nav {
+        .dropdown-toggle {
+            text-align: left;
+
+            @include xs {
+                width: auto;
+                display: inline-block;
+            }
+        }
+
+        .menu-item {
+            @include sm-and-up { // above mobile, the menu is horizontal
+                display: inline-block;
+                width: auto;
+            }
+        }
+
+        .nav-link {
+            padding: 10px;
+            @include xs {
+                padding: 5px 0;
+            }
+        }
+
+        // in mobile, submenus take up full width
+        .dropdown-menu {
+            border: 0;
+            box-shadow: none;
+            background-color: inherit;
+            text-align: left;
+
+            @include xs {
+                position: static;
+                width: 100%;
+                border: 0;
+                padding: 0;
+            }
+            @include sm-and-up {
+                padding: 0 10px;
+            }
+            .menu-item {
+                @include md-and-up {
+                    min-width: 180px;
+                }
+            }
+            .nav-link {
+                @include xs {
+                    padding: 5px 10px;
+                }
+            }
+        }
+        .dropdown-backdrop {
+            @include xs {
+                position: static;
+            }
+        }
+    }
+}

--- a/wp-content/themes/timber/setup/helpers/menus.php
+++ b/wp-content/themes/timber/setup/helpers/menus.php
@@ -10,7 +10,7 @@ register_nav_menus(array(
 ));
 
 function timber_menus( $data ) {
-    $data["header_menus"] = new TimberMenu('header');
+    $data["header_menu"] = new TimberMenu('header');
     // $data["footer_menus"] = new TimberMenu('footer');
     return $data;
 }

--- a/wp-content/themes/timber/views/layout.twig
+++ b/wp-content/themes/timber/views/layout.twig
@@ -92,7 +92,10 @@
             <script src="vendor/jquery-smooth-scroll/jquery.smooth-scroll.js"></script>
             <script src="vendor/cookies-js/dist/cookies.js"></script>
             <script src="vendor/FitVids/jquery.fitvids.js"></script>
+            <script src="vendor/twbs-bootstrap-sass/assets/javascripts/bootstrap/transition.js"></script>
             <script src="vendor/twbs-bootstrap-sass/assets/javascripts/bootstrap/dropdown.js"></script>
+            <script src="vendor/twbs-bootstrap-sass/assets/javascripts/bootstrap/collapse.js"></script>
+            <script src="vendor/bootstrap-hover-dropdown/bootstrap-hover-dropdown.js"></script>
             <script src="vendor/quickshare/dist/quickshare.js"></script>
             <script src="vendor/matchHeight/jquery.matchHeight.js"></script>
             <script src="js/console-safe.js"></script>

--- a/wp-content/themes/timber/views/partials/header.twig
+++ b/wp-content/themes/timber/views/partials/header.twig
@@ -1,28 +1,58 @@
-<header class="section bg-gray">
+<header class="section main-header bg-gray">
     <div class="container">
         <div class="row">
 
-            <div class="logo col-sm-3">
+            <div class="logo col-xs-6 col-sm-3">
                 <a href="/">{{ wp_title }}</a>
             </div>
 
-            <nav class="col-sm-9">
-                <ul class="nav navbar-nav navbar-right">
-                    {% for item in header_menus.get_items %}
-                        <li class="{{ item.get_children ? 'dropdown ' : '' }}{{ item.classes | join(' ') }}">
-                            <a href="{{ item.get_link }}" {{ item.get_children ? 'class="dropdown-toggle" data-toggle="dropdown" data-hover="dropdown"' : '' }} role="button" aria-expanded="false">{{ item.title }}</a>
-                            {% if item.get_children %}
-                                <ul class="dropdown-menu" role="menu">
-                                    {% for child in item.get_children %}
-                                        <li class="{{ item.classes | join(' ') }}"><a href="{{ child.get_link }}">{{ child.title }}</a></li>
-                                    {% endfor %}
-                                </ul>
-                            {% endif %}
-                        </li>
-                    {% endfor %}
-                </ul>
-            </nav>
+            <div class="col-xs-1 col-sm-6 main-header-nav-desktop-holder">
+                <nav class="main-header-nav">
+                    <ul class="top-level-menu">
+                        {% for item in header_menus.get_items %}
+                            <li class="text-uppercase {{ item.get_children ? 'dropdown ' : '' }}{{ item.classes | join(' ') }}">
+                                <a href="{{ item.get_link }}"
+                                    class="nav-link {{ item.get_children ? ' dropdown-toggle ' : '' }}"
+                                    {% if item.get_children %} data-hover="dropdown" {% endif %}
+                                    role="button" aria-expanded="false">
+                                    {{ item.title }}
+                                </a>
+                                {% if item.get_children %}
+                                    {#  In mobile, rather than hover, we have an dropdown
+                                        toggle link '+' for submenu items #}
+                                    <a href="#" class="plus-expand link-subtle visible-xs" data-toggle="dropdown" role="button" aria-expanded="false">
+                                        <i class="fa fa-plus"></i>
+                                    </a>
+                                    <ul class="dropdown-menu" role="menu">
+                                        {% for child in item.get_children %}
+                                            <li class="{{ item.classes | join(' ') }}"><a href="{{ child.get_link }}" class="nav-link">{{ child.title }}</a></li>
+                                        {% endfor %}
+                                    </ul>
+                                {% endif %}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </nav>
+            </div>
+
+            <div class="col-xs-5 col-sm-3">
+
+                <a class="menu-toggle pull-right visible-xs " role="button" data-toggle="collapse" href="#main-header-menu" aria-expanded="false" aria-controls="main-header-menu">
+                    <i class="fa fa-bars"></i>
+                </a>
+
+            </div>
 
         </div>
+
+        {# where mobile nav will appear#}
+        <div class="row">
+            <div class="col-sm-12">
+                <div class="main-header-nav-mobile-holder collapse" id="main-header-menu">
+
+                </div>
+            </div>
+        </div>
+
     </div>
 </header>

--- a/wp-content/themes/timber/views/partials/header.twig
+++ b/wp-content/themes/timber/views/partials/header.twig
@@ -1,3 +1,36 @@
+{# render menu macro  #}
+{% macro header_nav( menu, top_classes ) %}
+    <nav class="main-header-nav {{ top_classes }}">
+        <ul class="top-level-menu">
+            {% for item in menu.get_items %}
+                <li class="text-uppercase {{ item.get_children ? 'dropdown ' : '' }}{{ item.classes | join(' ') }}">
+                    <a href="{{ item.get_link }}"
+                        class="nav-link {{ item.get_children ? ' dropdown-toggle ' : '' }}"
+                        {% if item.get_children %} data-hover="dropdown" {% endif %}
+                        role="button" aria-expanded="false">
+                        {{ item.title }}
+                    </a>
+                    {% if item.get_children %}
+                        {#  In mobile, rather than hover, we have an dropdown
+                            toggle link '+' for submenu items #}
+                        <a href="#" class="plus-expand link-subtle visible-xs" data-toggle="dropdown" role="button" aria-expanded="false">
+                            <i class="fa fa-plus"></i>
+                        </a>
+                        <ul class="dropdown-menu" role="menu">
+                            {% for child in item.get_children %}
+                                <li class="{{ item.classes | join(' ') }}"><a href="{{ child.get_link }}" class="nav-link">{{ child.title }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+    </nav>
+{% endmacro %}
+{% import _self as lm %}
+
+
+{# header starts here #}
 <header class="section main-header bg-gray">
     <div class="container">
         <div class="row">
@@ -6,50 +39,22 @@
                 <a href="/">{{ wp_title }}</a>
             </div>
 
-            <div class="col-xs-1 col-sm-6 main-header-nav-desktop-holder">
-                <nav class="main-header-nav">
-                    <ul class="top-level-menu">
-                        {% for item in header_menus.get_items %}
-                            <li class="text-uppercase {{ item.get_children ? 'dropdown ' : '' }}{{ item.classes | join(' ') }}">
-                                <a href="{{ item.get_link }}"
-                                    class="nav-link {{ item.get_children ? ' dropdown-toggle ' : '' }}"
-                                    {% if item.get_children %} data-hover="dropdown" {% endif %}
-                                    role="button" aria-expanded="false">
-                                    {{ item.title }}
-                                </a>
-                                {% if item.get_children %}
-                                    {#  In mobile, rather than hover, we have an dropdown
-                                        toggle link '+' for submenu items #}
-                                    <a href="#" class="plus-expand link-subtle visible-xs" data-toggle="dropdown" role="button" aria-expanded="false">
-                                        <i class="fa fa-plus"></i>
-                                    </a>
-                                    <ul class="dropdown-menu" role="menu">
-                                        {% for child in item.get_children %}
-                                            <li class="{{ item.classes | join(' ') }}"><a href="{{ child.get_link }}" class="nav-link">{{ child.title }}</a></li>
-                                        {% endfor %}
-                                    </ul>
-                                {% endif %}
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </nav>
+            <div class="col-xs-1 col-sm-6">
+                {{ lm.header_nav(header_menu, 'hidden-xs') }} {# desktop menu #}
             </div>
 
             <div class="col-xs-5 col-sm-3">
-
                 <a class="menu-toggle pull-right visible-xs " role="button" data-toggle="collapse" href="#main-header-menu" aria-expanded="false" aria-controls="main-header-menu">
                     <i class="fa fa-bars"></i>
                 </a>
-
             </div>
-
         </div>
 
-        {# where mobile nav will appear#}
+        {# mobile menu #}
         <div class="row">
             <div class="col-sm-12">
                 <div class="main-header-nav-mobile-holder collapse" id="main-header-menu">
-
+                    {{ lm.header_nav(header_menu, 'visible-xs') }}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Per discussion in #44, this PR switches the current header navbar nav with a basic starter out of the box mobile nav . It's aims are two fold:

1. Remove dependency on bootstrap navbar and it's setup. Utilizing navbar added more constrictions than benefits (shown below).

2. Give a starter option for a basic responsive nav, solving typical needs (mobile nav expand)

Before:
====

* The desktop menu did not show submenu elements
![screenshot from 2017-06-13 13-14-12](https://user-images.githubusercontent.com/128731/27095057-4f1cb462-503a-11e7-81ea-ab42dda34ae2.png)


* The mobile menu was always open (increasing usage of space) and it too did not show submenu (dropdown elements) 
 ![screenshot from 2017-06-13 13-14-39](https://user-images.githubusercontent.com/128731/27095059-521a0598-503a-11e7-9aa2-90711288241f.png)


After (with this PR):
====

* The desktop nav has a default hover state for dropdown submenu elements (courtesy of bootstrap hover dropdown): 

![desktop-nav-demo](https://user-images.githubusercontent.com/128731/27094896-bba6e1b2-5039-11e7-9f9e-873985098280.gif)

* In mobile, the menu starts hidden, and a bars hamburger appears on the top right to toggle it open. If the menu item has a dropdown, it's toggleable with a '+' link

![mobile-nav-demo](https://user-images.githubusercontent.com/128731/27094823-81834872-5039-11e7-8783-753428793c11.gif)

As always, this is just an out of the box _default option_. Feel free to overwrite, if the design you're working with implies a different approach.
