### PR TITLE
64 external menu links

### DIFF
--- a/wp-content/themes/timber/views/partials/header.twig
+++ b/wp-content/themes/timber/views/partials/header.twig
@@ -5,6 +5,7 @@
             {% for item in menu.get_items %}
                 <li class="text-uppercase {{ item.get_children ? 'dropdown ' : '' }}{{ item.classes | join(' ') }}">
                     <a href="{{ item.get_link }}"
+                        {% if item.target %}target={{ item.target }}{% endif %}
                         class="nav-link {{ item.get_children ? ' dropdown-toggle ' : '' }}"
                         {% if item.get_children %} data-hover="dropdown" {% endif %}
                         role="button" aria-expanded="false">
@@ -18,7 +19,13 @@
                         </a>
                         <ul class="dropdown-menu" role="menu">
                             {% for child in item.get_children %}
-                                <li class="{{ item.classes | join(' ') }}"><a href="{{ child.get_link }}" class="nav-link">{{ child.title }}</a></li>
+                                <li class="{{ item.classes | join(' ') }}">
+                                    <a href="{{ child.get_link }}" class="nav-link"
+                                    {% if child.target %}target={{ child.target }}{% endif %}
+                                        >
+                                        {{ child.title }}
+                                    </a>
+                                </li>
                             {% endfor %}
                         </ul>
                     {% endif %}

--- a/wp-content/themes/timber/views/partials/header.twig
+++ b/wp-content/themes/timber/views/partials/header.twig
@@ -21,7 +21,7 @@
                             {% for child in item.get_children %}
                                 <li class="{{ item.classes | join(' ') }}">
                                     <a href="{{ child.get_link }}" class="nav-link"
-                                    {% if child.target %}target={{ child.target }}{% endif %}
+                                        {% if child.target %}target={{ child.target }}{% endif %}
                                         >
                                         {{ child.title }}
                                     </a>


### PR DESCRIPTION
This PR has the header nav links respect the wordpress option to open a link in a new tab.

![screenshot from 2017-06-14 15-27-23](https://user-images.githubusercontent.com/128731/27151587-ffb33196-5118-11e7-983b-4f7740b9df2c.png)
