### PR TITLE
87 upgrade to wp 4 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,27 +5,27 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "WordPress/WordPress": "4.8.2",
-        "advanced-custom-fields/advanced-custom-fields-pro": "5.6.2",
+        "WordPress/WordPress": "4.9.1",
+        "advanced-custom-fields/advanced-custom-fields-pro": "5.6.7",
         "norcross/airplane-mode": "0.2.2",
-        "roots/soil": "3.7.2",
+        "roots/soil": "3.7.3",
         "upstatement/routes": "0.4.0",
         "wpackagist-plugin/bottom-admin-bar": "1.3",
         "wpackagist-plugin/debug-bar": "0.9",
         "wpackagist-plugin/debug-bar-timber": "0.3",
         "wpackagist-plugin/disable-emojis": "1.7",
-        "wpackagist-plugin/duplicate-post": "3.2",
+        "wpackagist-plugin/duplicate-post": "3.2.1",
         "wpackagist-plugin/enable-media-replace": "3.1.1",
-        "wpackagist-plugin/filter-page-by-template": "1.0",
-        "wpackagist-plugin/google-apps-login": "3.0",
+        "wpackagist-plugin/filter-page-by-template": "1.1",
+        "wpackagist-plugin/google-apps-login": "3.2",
         "wpackagist-plugin/post-type-archive-links": "1.3.1",
         "wpackagist-plugin/post-type-switcher": "3.0.0",
-        "wpackagist-plugin/query-monitor": "2.14.0",
+        "wpackagist-plugin/query-monitor": "2.17.0",
         "wpackagist-plugin/term-management-tools": "1.1.4",
-        "wpackagist-plugin/timber-library": "1.5.0",
-        "wpackagist-plugin/transients-manager": "1.7.3",
-        "wpackagist-plugin/user-switching": "1.1.0",
-        "wpackagist-plugin/wordpress-seo": "5.5.1"
+        "wpackagist-plugin/timber-library": "1.6",
+        "wpackagist-plugin/transients-manager": "1.7.4",
+        "wpackagist-plugin/user-switching": "1.3.0",
+        "wpackagist-plugin/wordpress-seo": "6.1.1"
     },
     "repositories": [
         {
@@ -33,10 +33,10 @@
             "package": {
                 "name": "WordPress/WordPress",
                 "type": "webroot",
-                "version": "4.8.2",
+                "version": "4.9.1",
                 "dist": {
                     "type": "zip",
-                    "url": "https://github.com/WordPress/WordPress/archive/4.8.2.zip"
+                    "url": "https://github.com/WordPress/WordPress/archive/4.9.1.zip"
                 },
                 "require": {
                     "fancyguy/webroot-installer": "~1.1"
@@ -51,7 +51,7 @@
             "type": "package",
             "package": {
                 "name": "advanced-custom-fields/advanced-custom-fields-pro",
-                "version": "5.6.2",
+                "version": "5.6.7",
                 "type": "wordpress-plugin",
                 "dist": {
                     "type": "zip",

--- a/composer.lock
+++ b/composer.lock
@@ -4,14 +4,14 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c89c579c2cfdc4890b0c9ba97bef7cd8",
+    "content-hash": "448c5dcaadd6b191256f509dd5c8682d",
     "packages": [
         {
             "name": "WordPress/WordPress",
-            "version": "4.8.2",
+            "version": "4.9.1",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/WordPress/WordPress/archive/4.8.2.zip",
+                "url": "https://github.com/WordPress/WordPress/archive/4.9.1.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -19,25 +19,6 @@
                 "fancyguy/webroot-installer": "~1.1"
             },
             "type": "webroot"
-        },
-        {
-            "name": "advanced-custom-fields/advanced-custom-fields-pro",
-            "version": "5.6.2",
-            "dist": {
-                "type": "zip",
-                "url": "https://www.dropbox.com/s/rcrpbzl9ej29i1e/advanced-custom-fields-pro-5.6.2.zip?dl=1",
-                "reference": null,
-                "shasum": null
-            },
-            "require": {
-                "composer/installers": "v1.0.6"
-            },
-            "type": "wordpress-plugin",
-            "autoload": {
-                "psr-0": {
-                    "acf\\advanced-custom-fields-pro": ""
-                }
-            }
         },
         {
             "name": "altorouter/altorouter",
@@ -92,35 +73,39 @@
         },
         {
             "name": "composer/installers",
-            "version": "v1.0.6",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "b3bd071ea114a57212c75aa6a2eef5cfe0cc798f"
+                "reference": "049797d727261bf27f2690430d935067710049c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/b3bd071ea114a57212c75aa6a2eef5cfe0cc798f",
-                "reference": "b3bd071ea114a57212c75aa6a2eef5cfe0cc798f",
+                "url": "https://api.github.com/repos/composer/installers/zipball/049797d727261bf27f2690430d935067710049c2",
+                "reference": "049797d727261bf27f2690430d935067710049c2",
                 "shasum": ""
             },
+            "require": {
+                "composer-plugin-api": "^1.0"
+            },
             "replace": {
+                "roundcube/plugin-installer": "*",
                 "shama/baton": "*"
             },
             "require-dev": {
                 "composer/composer": "1.0.*@dev",
-                "phpunit/phpunit": "3.7.*"
+                "phpunit/phpunit": "^4.8.36"
             },
-            "type": "composer-installer",
+            "type": "composer-plugin",
             "extra": {
-                "class": "Composer\\Installers\\Installer",
+                "class": "Composer\\Installers\\Plugin",
                 "branch-alias": {
                     "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Composer\\Installers\\": "src/"
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -131,37 +116,80 @@
                 {
                     "name": "Kyle Robinson Young",
                     "email": "kyle@dontkry.com",
-                    "homepage": "https://github.com/shama",
-                    "role": "Developer"
+                    "homepage": "https://github.com/shama"
                 }
             ],
             "description": "A multi-framework Composer library installer",
-            "homepage": "http://composer.github.com/installers/",
+            "homepage": "https://composer.github.io/installers/",
             "keywords": [
-                "TYPO3 CMS",
-                "TYPO3 Flow",
-                "TYPO3 Neos",
+                "Craft",
+                "Dolibarr",
+                "Eliasis",
+                "Hurad",
+                "ImageCMS",
+                "Kanboard",
+                "Lan Management System",
+                "MODX Evo",
+                "Mautic",
+                "Maya",
+                "OXID",
+                "Plentymarkets",
+                "Porto",
+                "RadPHP",
+                "SMF",
+                "Thelia",
+                "WolfCMS",
                 "agl",
+                "aimeos",
+                "annotatecms",
+                "attogram",
+                "bitrix",
                 "cakephp",
+                "chef",
+                "cockpit",
                 "codeigniter",
+                "concrete5",
+                "croogo",
+                "dokuwiki",
                 "drupal",
+                "eZ Platform",
+                "elgg",
+                "expressionengine",
                 "fuelphp",
+                "grav",
                 "installer",
+                "itop",
                 "joomla",
                 "kohana",
                 "laravel",
-                "li3",
+                "lavalite",
                 "lithium",
+                "magento",
+                "majima",
                 "mako",
+                "mediawiki",
                 "modulework",
+                "modx",
+                "moodle",
+                "osclass",
                 "phpbb",
+                "piwik",
                 "ppi",
+                "puppet",
+                "pxcms",
+                "reindex",
+                "roundcube",
+                "shopware",
                 "silverstripe",
+                "sydes",
                 "symfony",
+                "typo3",
                 "wordpress",
-                "zend"
+                "yawik",
+                "zend",
+                "zikula"
             ],
-            "time": "2013-08-20T04:37:09+00:00"
+            "time": "2017-12-29T09:13:20+00:00"
         },
         {
             "name": "fancyguy/webroot-installer",
@@ -218,16 +246,16 @@
         },
         {
             "name": "roots/soil",
-            "version": "3.7.2",
+            "version": "3.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roots/soil.git",
-                "reference": "09368d6db8c40daa9cc94054b0d1a16e6113e3e5"
+                "reference": "d0e409e70dafff4ceeaa8ef941ee319e350317dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/roots/soil/zipball/09368d6db8c40daa9cc94054b0d1a16e6113e3e5",
-                "reference": "09368d6db8c40daa9cc94054b0d1a16e6113e3e5",
+                "url": "https://api.github.com/repos/roots/soil/zipball/d0e409e70dafff4ceeaa8ef941ee319e350317dd",
+                "reference": "d0e409e70dafff4ceeaa8ef941ee319e350317dd",
                 "shasum": ""
             },
             "require": {
@@ -259,7 +287,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2017-06-12T01:25:19+00:00"
+            "time": "2017-08-14T01:36:41+00:00"
         },
         {
             "name": "upstatement/routes",
@@ -394,15 +422,15 @@
         },
         {
             "name": "wpackagist-plugin/duplicate-post",
-            "version": "3.2",
+            "version": "3.2.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/duplicate-post/",
-                "reference": "tags/3.2"
+                "reference": "tags/3.2.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/duplicate-post.3.2.zip",
+                "url": "https://downloads.wordpress.org/plugin/duplicate-post.3.2.1.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -434,15 +462,15 @@
         },
         {
             "name": "wpackagist-plugin/filter-page-by-template",
-            "version": "1.0",
+            "version": "1.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/filter-page-by-template/",
-                "reference": "tags/1.0"
+                "reference": "tags/1.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/filter-page-by-template.1.0.zip",
+                "url": "https://downloads.wordpress.org/plugin/filter-page-by-template.1.1.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -454,15 +482,15 @@
         },
         {
             "name": "wpackagist-plugin/google-apps-login",
-            "version": "3.0",
+            "version": "3.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/google-apps-login/",
-                "reference": "tags/3.0"
+                "reference": "tags/3.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/google-apps-login.3.0.zip",
+                "url": "https://downloads.wordpress.org/plugin/google-apps-login.3.2.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -514,15 +542,15 @@
         },
         {
             "name": "wpackagist-plugin/query-monitor",
-            "version": "2.14.0",
+            "version": "2.17.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/query-monitor/",
-                "reference": "tags/2.14.0"
+                "reference": "tags/2.17.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/query-monitor.2.14.0.zip",
+                "url": "https://downloads.wordpress.org/plugin/query-monitor.2.17.0.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -554,15 +582,15 @@
         },
         {
             "name": "wpackagist-plugin/timber-library",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/timber-library/",
-                "reference": "tags/1.5.0"
+                "reference": "tags/1.6.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/timber-library.1.5.0.zip",
+                "url": "https://downloads.wordpress.org/plugin/timber-library.1.6.0.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -574,15 +602,15 @@
         },
         {
             "name": "wpackagist-plugin/transients-manager",
-            "version": "1.7.3",
+            "version": "1.7.4",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/transients-manager/",
-                "reference": "trunk"
+                "reference": "tags/1.7.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/transients-manager.zip?timestamp=1496672955",
+                "url": "https://downloads.wordpress.org/plugin/transients-manager.1.7.4.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -594,15 +622,15 @@
         },
         {
             "name": "wpackagist-plugin/user-switching",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/user-switching/",
-                "reference": "tags/1.1.0"
+                "reference": "tags/1.3.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/user-switching.1.1.0.zip",
+                "url": "https://downloads.wordpress.org/plugin/user-switching.1.3.0.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -614,15 +642,15 @@
         },
         {
             "name": "wpackagist-plugin/wordpress-seo",
-            "version": "5.5.1",
+            "version": "6.1.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordpress-seo/",
-                "reference": "tags/5.5.1"
+                "reference": "tags/6.1.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.5.5.1.zip",
+                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.6.1.1.zip",
                 "reference": null,
                 "shasum": null
             },


### PR DESCRIPTION
This PR updates to the latest stable wordpress 4.9.1. and updates the wordpress plugins (Timber, soil, ..) as well. Both the front end theme and backend admin were tested and seem normal:

![screenshot from 2018-01-10 11-03-14](https://user-images.githubusercontent.com/128731/34782353-6a7789c8-f5f6-11e7-9577-ecaf1cde26e9.png)
