### PR TITLE
85 json api plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "norcross/airplane-mode": "0.2.2",
         "roots/soil": "3.7.3",
         "upstatement/routes": "0.4.0",
+        "wpackagist-plugin/acf-to-wp-api": "1.4.0",
         "wpackagist-plugin/bottom-admin-bar": "1.3",
         "wpackagist-plugin/debug-bar": "0.9",
         "wpackagist-plugin/debug-bar-timber": "0.3",
@@ -25,7 +26,9 @@
         "wpackagist-plugin/timber-library": "1.6",
         "wpackagist-plugin/transients-manager": "1.7.4",
         "wpackagist-plugin/user-switching": "1.3.0",
-        "wpackagist-plugin/wordpress-seo": "6.1.1"
+        "wpackagist-plugin/wordpress-seo": "6.1.1",
+        "wpackagist-plugin/wp-api-yoast-meta": "1.2.0",
+        "wpackagist-plugin/wp-rest-api-v2-menus": "0.3"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "448c5dcaadd6b191256f509dd5c8682d",
+    "content-hash": "e3cb087d83c90621b265b19b55b557ff",
     "packages": [
         {
             "name": "WordPress/WordPress",
@@ -341,6 +341,26 @@
             "time": "2016-07-06T12:53:24+00:00"
         },
         {
+            "name": "wpackagist-plugin/acf-to-wp-api",
+            "version": "1.4.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/acf-to-wp-api/",
+                "reference": "tags/1.4.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/acf-to-wp-api.1.4.0.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/acf-to-wp-api/"
+        },
+        {
             "name": "wpackagist-plugin/bottom-admin-bar",
             "version": "1.3",
             "source": {
@@ -659,6 +679,46 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wordpress-seo/"
+        },
+        {
+            "name": "wpackagist-plugin/wp-api-yoast-meta",
+            "version": "1.2.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wp-api-yoast-meta/",
+                "reference": "trunk"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-api-yoast-meta.zip?timestamp=1469793730",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wp-api-yoast-meta/"
+        },
+        {
+            "name": "wpackagist-plugin/wp-rest-api-v2-menus",
+            "version": "0.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wp-rest-api-v2-menus/",
+                "reference": "tags/0.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-rest-api-v2-menus.0.3.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wp-rest-api-v2-menus/"
         }
     ],
     "packages-dev": [],

--- a/wp-content/themes/timber/functions.php
+++ b/wp-content/themes/timber/functions.php
@@ -51,6 +51,13 @@
     include_once 'setup/helpers/menus.php';
     include_once 'setup/helpers/rev.php';
 
+    // Optional postlight inspired conveniences for headless wp (Get json data by slug, etc.)
+    // See https://github.com/postlight/headless-wp-starter/
+    // redirects the resulting posts/pages to their json data rather than a rendered theme page
+    // Uncomment the following and also see setup/json-api/redirect-samples.php for enabling page/post redirects
+    // include_once 'setup/json-api/logs.php';
+    // include_once 'setup/json-api/cors.php';
+    // include_once 'setup/json-api/api-routes.php';
 
     // Wordpress Theme Support Config
     // REMOVAL OF THESE = POTIENTAL LOSS OF DATA

--- a/wp-content/themes/timber/setup/json-api/api-routes.php
+++ b/wp-content/themes/timber/setup/json-api/api-routes.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Register custom REST API routes.
+ */
+add_action( 'rest_api_init', function () {
+	// Define API endpoint arguments
+	$slug_arg = array(
+		'validate_callback' => function ( $param, $request, $key ) {
+			return( is_string( $param ) );
+		}
+	);
+	$post_slug_arg = array_merge( $slug_arg, array( 'description' => 'String representing a valid WordPress post slug' ) );
+
+	$page_slug_arg = array_merge( $slug_arg, array( 'description' => 'String representing a valid WordPress page slug' ) );
+
+	// Register routes
+	register_rest_route( 'postlight/v1', '/post', array(
+		'methods'  => 'GET',
+		'callback' => 'rest_get_post',
+		'args' => array(
+			'slug' => array_merge( $post_slug_arg, array( 'required' => true ) ),
+		)
+	) );
+
+	register_rest_route( 'postlight/v1', '/page', array(
+		'methods'  => 'GET',
+		'callback' => 'rest_get_page',
+		'args' => array(
+			'slug' => array_merge( $page_slug_arg, array( 'required' => true ) ),
+		)
+	) );
+});
+
+/**
+ * Respond to a REST API request to get post data.
+ *
+ * @param WP_REST_Request $request
+ * @return WP_REST_Response
+ */
+function rest_get_post( WP_REST_Request $request ) {
+	return rest_get_content( $request, 'post', __FUNCTION__ );
+}
+
+/**
+ * Respond to a REST API request to get page data.
+ *
+ * @param WP_REST_Request $request
+ * @return WP_REST_Response
+ */
+function rest_get_page( WP_REST_Request $request ) {
+	return rest_get_content( $request, 'page', __FUNCTION__ );
+}
+
+/**
+ * Respond to a REST API request to get post or page data.
+ * * Handles changed slugs
+ * * Doesn't return posts whose status isn't published
+ * * Redirects to the admin when an edit parameter is present
+ *
+ * @param WP_REST_Request $request
+ * @param str $type
+ * @param str $function_name
+ * @return WP_REST_Response
+ */
+function rest_get_content( WP_REST_Request $request, $type, $function_name ) {
+	if ( ! in_array( $type, array ( 'post', 'page' ) ) ) {
+		$type = 'post';
+	}
+	$slug = $request->get_param( 'slug');
+	if ( ! $post = get_content_by_slug( $slug, $type ) ) {
+		return new WP_Error(
+			$function_name,
+			$slug . ' ' . $type . ' does not exist',
+			array( 'status' => 404 )
+		);
+	};
+
+	// Shortcut to WP admin page editor
+	$edit = $request->get_param( 'edit' );
+	if ( $edit === 'true' ) {
+		header( 'Location: /wp-admin/post.php?post=' . $post->ID . '&action=edit' );
+		exit;
+	}
+	$controller = new WP_REST_Posts_Controller( 'post' );
+	$data = $controller->prepare_item_for_response( $post, $request );
+	$response = $controller->prepare_response_for_collection( $data );
+
+	return new WP_REST_Response( $response );
+}
+
+/**
+ * Returns a post or page given a slug. Returns false if no post matches.
+ *
+ * @param str $slug
+ * @param str $type Valid values are 'post' or 'page'
+ * @return Post
+ */
+function get_content_by_slug( $slug, $type = 'post' ) {
+	if ( ! in_array( $type, array ( 'post', 'page' ) ) ) {
+		$type = 'post';
+	}
+	$args = array(
+		'name'        => $slug,
+		'post_type'   => $type,
+		'post_status' => 'publish',
+		'numberposts' => 1
+	);
+
+	$post_search_results = get_posts( $args );
+
+	if ( !$post_search_results ) { //maybe the slug changed?
+		// check wp_postmeta table for old slug
+		$args = array(
+			'meta_query' => array(
+				array(
+					'key' => '_wp_old_slug',
+					'value' => $post_slug,
+					'compare' => '=',
+				)
+			)
+		);
+		$query = new WP_Query( $args );
+		$post_search_results = $query->posts;
+	}
+	if ( isset( $post_search_results[0] ) ) {
+		return $post_search_results[0];
+	}
+	return false;
+}

--- a/wp-content/themes/timber/setup/json-api/cors.php
+++ b/wp-content/themes/timber/setup/json-api/cors.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Allow GET requests from * origin
+ * Thanks to https://joshpress.net/access-control-headers-for-the-wordpress-rest-api/
+ */
+add_action( 'rest_api_init', function() {
+	remove_filter( 'rest_pre_serve_request', 'rest_send_cors_headers' );
+	add_filter( 'rest_pre_serve_request', function( $value ) {
+		header( 'Access-Control-Allow-Origin: *' );
+		header( 'Access-Control-Allow-Methods: GET' );
+		header( 'Access-Control-Allow-Credentials: true' );
+		return $value;
+	});
+}, 15 );

--- a/wp-content/themes/timber/setup/json-api/logs.php
+++ b/wp-content/themes/timber/setup/json-api/logs.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Logs messages/variables/data to browser console from within php
+ * Thanks to https://codeinphp.github.io/post/outputting-php-to-browser-console/
+ *
+ * To use this, in your PHP template inside PHP tags, add a line like this:
+ *  log_console('$mobile_image_size_inline_style var', $mobile_image_size_inline_style, true);
+ *
+ * @param $name: message to be shown for optional data/vars
+ * @param $data: variable (scalar/mixed) arrays/objects, etc to be logged
+ * @param $js_eval: whether to apply JS eval() to arrays/objects
+ *
+ * @return none
+ * @author Sarfraz
+ */
+function log_console( $name, $data = null, $js_eval = false ) {
+	if ( ! $name ) {
+		return false;
+	}
+	$is_evaled = false;
+	$type = ( $data || gettype( $data ) ) ? 'Type: ' . gettype( $data ) : '';
+	if ( $js_eval && ( is_array( $data ) || is_object( $data ) ) ) {
+		$data = 'eval(' . preg_replace( '#[\s\r\n\t\0\x0B]+#', '', wp_json_encode( $data ) ) . ')';
+		$is_evaled = true;
+	} else {
+		$data = wp_json_encode( $data );
+	}
+	# sanitalize
+	$data = $data ? $data : '';
+	$search_array = array( "#'#", '#""#', "#''#", "#\n#", "#\r\n#" );
+	$replace_array = array( '"', '', '', '\\n', '\\n' );
+	$data = preg_replace( $search_array,  $replace_array, $data );
+	$data = ltrim( rtrim( $data, '"' ), '"' );
+	$data = $is_evaled ? $data : ( "'" === $data[0] ) ? $data : "'" . $data . "'";
+	$js = <<<JSCODE
+\n<script>
+ // fallback - to deal with IE (or browsers that don't have console)
+ if (! window.console) console = {};
+ console.log = console.log || function(name, data){};
+ // end of fallback
+ console.log('$name');
+ console.log('------------------------------------------');
+ console.log('$type');
+ console.log($data);
+ console.log('\\n');
+</script>
+JSCODE;
+	echo $js;
+}
+/**
+ * Log a value in wp-content/debug.log.
+ * To turn on, add the following to wp-config.php:
+ *
+ * define( 'WP_DEBUG', true );
+ * define( 'WP_DEBUG_LOG', true );  // Turn logging to wp-content/debug.log ON
+ * define( 'WP_DEBUG_DISPLAY', false ); // Keep JSON response valid
+ * @ini_set( 'display_errors', 0 ); // Keep JSON responses valid
+ *
+ * NOT INTENDED FOR PRODUCTION USE.
+ *
+ * @param str $message
+ * @param str $file Filename, defaults to __FILE__
+ * @param str $line Line number, defaults to __LINE__
+ * @return null
+ */
+function log_it( $message, $file = __FILE__, $line = __LINE__ ) {
+	if ( WP_DEBUG === true ) {
+		if ( is_array( $message ) || is_object( $message ) ) {
+			error_log( $file . 'L' . $line . ' ' . ( print_r( $message, true ) ) );
+		} else {
+			error_log( $file . 'L' . $line . ' ' . $message );
+		}
+	}
+}

--- a/wp-content/themes/timber/setup/json-api/redirect-samples.php
+++ b/wp-content/themes/timber/setup/json-api/redirect-samples.php
@@ -1,0 +1,11 @@
+<?php
+// inspired from: https://github.com/postlight/headless-wp-starter/blob/master/wordpress/wp-content/themes/postlight-headless-wp/index.php
+// Redirect individual post and pages to the REST API endpoint
+
+// To auto redirect pages and posts to the their json data
+// in page.php (or a page template), to redirect, for example, from /sample-page to it's json   for example:
+// add to the bottom of page.php:
+// header( 'Location: /wp-json/wp/v2/pages/' . get_queried_object()->ID );
+
+// Similarly in single.php to redirect from /posts/some-post to  the json for it
+//  header( 'Location: /wp-json/wp/v2/posts/' . get_post()->ID );


### PR DESCRIPTION
This PR does two main things, per #85 :

* adds three wordpress plugins to provide access 

![screenshot from 2018-01-10 11-35-09](https://user-images.githubusercontent.com/128731/34783850-a4773b88-f5fa-11e7-9c7a-fd3fc679af28.png)

This enables access to posts via 
API Json for Sample Page:
http://www.bubs.loc/wp-json/wp/v2/pages/2

Altenate route provided by postlight (api-routes.php) using slug:
http://www.bubs.loc/wp-json/postlight/v1/page/?slug=sample-page

![screenshot from 2018-01-10 11-45-10](https://user-images.githubusercontent.com/128731/34785365-e8b4391e-f5fe-11e7-818f-1565e496caff.png)

* Additionally , files that turn the theme to a "headless one" (one focusing on providing json api data of posts, acf, ... have been added ([commented out](https://github.com/patronage/bubs/blob/85-json-api-plugins/wp-content/themes/timber/functions.php#L54-L60) with instructions).

If enabled, pages and posts redirect to the json:
ex: http://www.bubs.loc/sample-page/ -> http://www.bubs.loc/wp-json/wp/v2/pages/2
