### PR TITLE
18 boostrap 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "WordPress/WordPress": "4.9.1",
+        "WordPress/WordPress": "4.9.2",
         "advanced-custom-fields/advanced-custom-fields-pro": "5.6.7",
         "norcross/airplane-mode": "0.2.2",
         "roots/soil": "3.7.3",
@@ -37,10 +37,10 @@
             "package": {
                 "name": "WordPress/WordPress",
                 "type": "webroot",
-                "version": "4.9.1",
+                "version": "4.9.2",
                 "dist": {
                     "type": "zip",
-                    "url": "https://github.com/WordPress/WordPress/archive/4.9.1.zip"
+                    "url": "https://github.com/WordPress/WordPress/archive/4.9.2.zip"
                 },
                 "require": {
                     "fancyguy/webroot-installer": "~1.1"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "run-sequence": "2.2.1"
   },
   "dependencies": {
-    "@bower_components/fitvids": "davatron5000/FitVids.js#^1.2.0",
+    "@bower_components/fitvids": "davatron5000/fitvids.js#^1.2.0",
     "autotrack": "2.4.1",
     "bootstrap": "4.0.0",
     "cookies-js": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@bower_components/fitvids": "davatron5000/FitVids.js#^1.2.0",
     "autotrack": "2.4.1",
-    "bootstrap": "4.0.0-beta.3",
+    "bootstrap": "4.0.0",
     "cookies-js": "1.2.3",
     "jquery": "3.2.1",
     "jquery-match-height": "0.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -346,9 +346,9 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bootstrap@4.0.0-beta.3:
-  version "4.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.3.tgz#60f0660bc3d121176514b361f6f83201c7ff8874"
+bootstrap@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0.tgz#ceb03842c145fcc1b9b4e15da2a05656ba68469a"
 
 brace-expansion@^1.0.0:
   version "1.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@bower_components/fitvids@davatron5000/FitVids.js#^1.2.0":
+"@bower_components/fitvids@davatron5000/fitvids.js#^1.2.0":
   version "0.0.0"
-  resolved "https://codeload.github.com/davatron5000/FitVids.js/tar.gz/d028a2287a633478005a49fe6d1f3fcbe9f2d955"
+  resolved "https://codeload.github.com/davatron5000/fitvids.js/tar.gz/d028a2287a633478005a49fe6d1f3fcbe9f2d955"
 
 "@gulp-sourcemaps/identity-map@1.X":
   version "1.0.1"


### PR DESCRIPTION
This PR does two main things per #18 .

* bump bootstrap from beta version to officiel 4.0.0 release
* bump latest wordpress to 4.9.2 (from 4.9.1)

Tested both locally and they seem fine.