### PR TITLE
adjust margin of alignment to value with units so that style is valid…

### DIFF
--- a/wp-content/themes/timber/assets/scss/modules/_wordpress.scss
+++ b/wp-content/themes/timber/assets/scss/modules/_wordpress.scss
@@ -10,23 +10,23 @@
 
 .aligncenter {
     display: block;
-    margin: ($line-height-base / 2) auto;
+    margin: $font-size-base auto;
 }
 
 .alignleft,
 .alignright {
-    margin-bottom: ($line-height-base / 2);
+    margin-bottom: ($font-size-base / 2);
 }
 
 @include media-breakpoint-up(sm) {
   // Only float if not on an extra small device
     .alignleft {
         float: left;
-        margin-right: ($line-height-base / 2);
+        margin-right: ($font-size-base / 2);
     }
     .alignright {
         float: right;
-        margin-left: ($line-height-base / 2);
+        margin-left: ($font-size-base / 2);
     }
 }
 


### PR DESCRIPTION
… and applied

This PR adjusts the wordpress margin styles to use a value with a unit so the result is applied by the browsers.

Here  is the example noted in #93: 

![screenshot_20180329_115715](https://user-images.githubusercontent.com/128731/38099351-5f1e41e0-3348-11e8-9a6d-162f595562f6.png)

With this adjustment, the center alignment now works.