### PR TITLE
add  snippet to prevent single word lines

### DIFF
--- a/wp-content/themes/timber/assets/js/main.js
+++ b/wp-content/themes/timber/assets/js/main.js
@@ -26,6 +26,20 @@ var headerNav = function(){
     });
 };
 
+// a widow (single word on it's own line) adjuster. Typically fills in the last line with previous word(s)
+// inspired by http://justinhileman.info/article/a-jquery-widont-snippet/
+var widont = function() {
+    $('h1,h2,h3,p').each(function() {
+        var $element = $(this);
+
+        // use  .no-widont to opt out of using it on the element above (handy for react element, highlighed text, ..)
+        if ($element.hasClass('no-widont')){
+            return;
+        }
+        $element.html($(this).html().replace(/\s([^\s<]{0,8})\s*$/,'&nbsp;$1'));
+    });
+};
+
 // init within document.ready
 (function($) {
 
@@ -34,5 +48,6 @@ var headerNav = function(){
     matchHeightInit();
     smoothScrollInit();
     analyticsSourcing();
+    widont();
 
 })(jQuery);


### PR DESCRIPTION
This PR adds a js snippet to prevent "widowed" (one word) lines to help improve their readability. 

![screenshot_20180821_161101](https://user-images.githubusercontent.com/128731/44426517-d7268400-a55c-11e8-9c7c-13aea8d786d4.png)

Notes
* The snippet is already in use on a few of the sites bubs is being used with.
* The tags it applies to can be adjusted depending on need. 
* You can also opt out of the snippet on specific instances of the tag by adding a `no-widont class to that tag.
`