### PR TITLE
100 wp n plugin upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,32 +5,33 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "WordPress/WordPress": "4.9.8",
-        "advanced-custom-fields/advanced-custom-fields-pro": "5.6.7",
+        "WordPress/WordPress": "5.0.3",
+        "advanced-custom-fields/advanced-custom-fields-pro": "5.7.11",
         "norcross/airplane-mode": "0.2.2",
         "roots/soil": "3.7.3",
         "upstatement/routes": "0.4.0",
         "wpackagist-plugin/acf-to-wp-api": "1.4.0",
         "wpackagist-plugin/bottom-admin-bar": "1.3",
-        "wpackagist-plugin/classic-editor": "0.4",
-        "wpackagist-plugin/debug-bar": "0.9",
+        "wpackagist-plugin/classic-editor":"1.4",
+        "wpackagist-plugin/debug-bar": "1.0",
         "wpackagist-plugin/debug-bar-timber": "0.3",
         "wpackagist-plugin/disable-emojis": "1.7.2",
         "wpackagist-plugin/duplicate-post": "3.2.2",
-        "wpackagist-plugin/enable-media-replace": "3.2.7",
+        "wpackagist-plugin/enable-media-replace":"3.2.8",
         "wpackagist-plugin/filter-page-by-template": "1.2",
         "wpackagist-plugin/google-apps-login": "3.2",
+        "wpackagist-plugin/gutenberg-ramp":"1.1.0",
         "wpackagist-plugin/post-type-archive-links": "1.3.1",
         "wpackagist-plugin/post-type-switcher": "3.1.0",
-        "wpackagist-plugin/query-monitor": "3.1.0",
+        "wpackagist-plugin/query-monitor": "3.2.2",
         "wpackagist-plugin/quick-pagepost-redirect-plugin": "5.1.8",
         "wpackagist-plugin/term-management-tools": "1.1.4",
-        "wpackagist-plugin/timber-library": "1.7.1",
+        "wpackagist-plugin/timber-library": "1.8.4",
         "wpackagist-plugin/transients-manager": "1.7.5",
-        "wpackagist-plugin/user-switching": "1.3.1",
-        "wpackagist-plugin/wordpress-seo": "8.0",
+        "wpackagist-plugin/user-switching":"1.4.2",
+        "wpackagist-plugin/wordpress-seo":"9.6",
         "wpackagist-plugin/wp-api-yoast-meta": "1.2.0",
-        "wpackagist-plugin/wp-rest-api-v2-menus": "0.3.1"
+        "wpackagist-plugin/wp-rest-api-v2-menus":"0.3.2"
     },
     "repositories": [
         {
@@ -38,10 +39,10 @@
             "package": {
                 "name": "WordPress/WordPress",
                 "type": "webroot",
-                "version": "4.9.8",
+                "version": "5.0.3",
                 "dist": {
                     "type": "zip",
-                    "url": "https://github.com/WordPress/WordPress/archive/4.9.8.zip"
+                    "url": "https://github.com/WordPress/WordPress/archive/5.0.3.zip"
                 },
                 "require": {
                     "fancyguy/webroot-installer": "~1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -1,17 +1,17 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e3cb087d83c90621b265b19b55b557ff",
+    "content-hash": "fa77461692f8f3cf23c05180aab941c4",
     "packages": [
         {
             "name": "WordPress/WordPress",
-            "version": "4.9.1",
+            "version": "5.0.3",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/WordPress/WordPress/archive/4.9.1.zip",
+                "url": "https://github.com/WordPress/WordPress/archive/5.0.3.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -73,16 +73,16 @@
         },
         {
             "name": "composer/installers",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "049797d727261bf27f2690430d935067710049c2"
+                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/049797d727261bf27f2690430d935067710049c2",
-                "reference": "049797d727261bf27f2690430d935067710049c2",
+                "url": "https://api.github.com/repos/composer/installers/zipball/cfcca6b1b60bc4974324efb5783c13dca6932b5b",
+                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b",
                 "shasum": ""
             },
             "require": {
@@ -189,7 +189,7 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2017-12-29T09:13:20+00:00"
+            "time": "2018-08-27T06:10:37+00:00"
         },
         {
             "name": "fancyguy/webroot-installer",
@@ -381,16 +381,36 @@
             "homepage": "https://wordpress.org/plugins/bottom-admin-bar/"
         },
         {
-            "name": "wpackagist-plugin/debug-bar",
-            "version": "0.9",
+            "name": "wpackagist-plugin/classic-editor",
+            "version": "1.4",
             "source": {
                 "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/debug-bar/",
-                "reference": "tags/0.9"
+                "url": "https://plugins.svn.wordpress.org/classic-editor/",
+                "reference": "tags/1.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/debug-bar.0.9.zip",
+                "url": "https://downloads.wordpress.org/plugin/classic-editor.1.4.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/classic-editor/"
+        },
+        {
+            "name": "wpackagist-plugin/debug-bar",
+            "version": "1.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/debug-bar/",
+                "reference": "tags/1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/debug-bar.1.0.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -422,15 +442,15 @@
         },
         {
             "name": "wpackagist-plugin/disable-emojis",
-            "version": "1.7",
+            "version": "1.7.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/disable-emojis/",
-                "reference": "tags/1.7"
+                "reference": "tags/1.7.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/disable-emojis.1.7.zip",
+                "url": "https://downloads.wordpress.org/plugin/disable-emojis.1.7.2.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -442,15 +462,15 @@
         },
         {
             "name": "wpackagist-plugin/duplicate-post",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/duplicate-post/",
-                "reference": "tags/3.2.1"
+                "reference": "tags/3.2.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/duplicate-post.3.2.1.zip",
+                "url": "https://downloads.wordpress.org/plugin/duplicate-post.3.2.2.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -462,15 +482,15 @@
         },
         {
             "name": "wpackagist-plugin/enable-media-replace",
-            "version": "3.1.1",
+            "version": "3.2.8",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/enable-media-replace/",
-                "reference": "tags/3.1.1"
+                "reference": "tags/3.2.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/enable-media-replace.3.1.1.zip",
+                "url": "https://downloads.wordpress.org/plugin/enable-media-replace.3.2.8.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -482,15 +502,15 @@
         },
         {
             "name": "wpackagist-plugin/filter-page-by-template",
-            "version": "1.1",
+            "version": "1.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/filter-page-by-template/",
-                "reference": "tags/1.1"
+                "reference": "tags/1.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/filter-page-by-template.1.1.zip",
+                "url": "https://downloads.wordpress.org/plugin/filter-page-by-template.1.2.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -521,6 +541,26 @@
             "homepage": "https://wordpress.org/plugins/google-apps-login/"
         },
         {
+            "name": "wpackagist-plugin/gutenberg-ramp",
+            "version": "1.1.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/gutenberg-ramp/",
+                "reference": "tags/1.1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/gutenberg-ramp.1.1.0.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/gutenberg-ramp/"
+        },
+        {
             "name": "wpackagist-plugin/post-type-archive-links",
             "version": "1.3.1",
             "source": {
@@ -542,15 +582,15 @@
         },
         {
             "name": "wpackagist-plugin/post-type-switcher",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/post-type-switcher/",
-                "reference": "trunk"
+                "reference": "tags/3.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/post-type-switcher.zip?timestamp=1479638531",
+                "url": "https://downloads.wordpress.org/plugin/post-type-switcher.3.1.0.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -562,15 +602,15 @@
         },
         {
             "name": "wpackagist-plugin/query-monitor",
-            "version": "2.17.0",
+            "version": "3.2.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/query-monitor/",
-                "reference": "tags/2.17.0"
+                "reference": "tags/3.2.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/query-monitor.2.17.0.zip",
+                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.2.2.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -579,6 +619,26 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/query-monitor/"
+        },
+        {
+            "name": "wpackagist-plugin/quick-pagepost-redirect-plugin",
+            "version": "5.1.8",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/quick-pagepost-redirect-plugin/",
+                "reference": "tags/5.1.8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/quick-pagepost-redirect-plugin.5.1.8.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/quick-pagepost-redirect-plugin/"
         },
         {
             "name": "wpackagist-plugin/term-management-tools",
@@ -602,15 +662,15 @@
         },
         {
             "name": "wpackagist-plugin/timber-library",
-            "version": "1.6.0",
+            "version": "1.8.4",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/timber-library/",
-                "reference": "tags/1.6.0"
+                "reference": "tags/1.8.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/timber-library.1.6.0.zip",
+                "url": "https://downloads.wordpress.org/plugin/timber-library.1.8.4.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -622,15 +682,15 @@
         },
         {
             "name": "wpackagist-plugin/transients-manager",
-            "version": "1.7.4",
+            "version": "1.7.5",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/transients-manager/",
-                "reference": "tags/1.7.4"
+                "reference": "trunk"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/transients-manager.1.7.4.zip",
+                "url": "https://downloads.wordpress.org/plugin/transients-manager.zip?timestamp=1532486424",
                 "reference": null,
                 "shasum": null
             },
@@ -642,15 +702,15 @@
         },
         {
             "name": "wpackagist-plugin/user-switching",
-            "version": "1.3.0",
+            "version": "1.4.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/user-switching/",
-                "reference": "tags/1.3.0"
+                "reference": "tags/1.4.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/user-switching.1.3.0.zip",
+                "url": "https://downloads.wordpress.org/plugin/user-switching.1.4.2.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -662,15 +722,15 @@
         },
         {
             "name": "wpackagist-plugin/wordpress-seo",
-            "version": "6.1.1",
+            "version": "9.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordpress-seo/",
-                "reference": "tags/6.1.1"
+                "reference": "tags/9.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.6.1.1.zip",
+                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.9.6.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -702,15 +762,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-rest-api-v2-menus",
-            "version": "0.3",
+            "version": "0.3.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-rest-api-v2-menus/",
-                "reference": "tags/0.3"
+                "reference": "tags/0.3.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-rest-api-v2-menus.0.3.zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-rest-api-v2-menus.0.3.2.zip",
                 "reference": null,
                 "shasum": null
             },


### PR DESCRIPTION
This PR updates the Wordpress core + open source plugins, per #100 

Tested in recent usages and locally on a bubs sample: 

![screenshot_20190213_114353](https://user-images.githubusercontent.com/128731/52728105-ad3aa100-2f84-11e9-9fb8-6869dc29f357.png)
  