### PR TITLE
WP Engine Deploy action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,44 @@
+name: Production Deploy to WP Engine
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  wp_engine_build_deploy:
+    runs-on: ubuntu-latest
+    name: Deploy to WP Engine
+    steps:
+      # To use this repository's private action, you must check out the repository
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '8.x'
+      - run: yarn
+      - run: gulp release
+      - name: WP Engine
+        uses: "patronage/bubs-wpengine-deploy@master"
+        env:
+          WPENGINE_SSH_KEY_PRIVATE: ${{ secrets.WPENGINE_SSH_KEY_PRIVATE }}
+          WPENGINE_SSH_KEY_PUBLIC: ${{ secrets.WPENGINE_SSH_KEY_PUBLIC }}
+          WPENGINE_ENVIRONMENT_NAME: bubs
+          LOCAL_BRANCH: master
+      - name: Slack Notification
+        if: success()
+        uses: rtCamp/action-slack-notify@v2.0.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_COLOR: good
+          SLACK_TITLE: "Build succeeded:"
+          SLACK_USERNAME: "Github Actions"
+      - name: Slack Notification
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2.0.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_COLOR: danger
+          SLACK_TITLE: "Build failed:"
+          SLACK_USERNAME: "Github Actions"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ ignoreThis(); // jshint ignore:line
 
 You can read more about [JSHint here](https://jshint.com/docs/)
 
+## Auto Deployment to WP Engine via Github Actions
+We've included a Github Action (in the `.github/` folder) which can be used to deploy your site to WP Engine after deploying some changes to the `master` branch on Github. JS and SCSS assets are built using `gulp`, and everything deploys as it would if you ran `sh _build/deploy.sh`. The Github action deploy is optional and can be removed if you are not using WP Engine or do not want your site to automatically deploy.
+
+In order to setup, a SSH key needs to be created and the private & public keys need to be set inside the Secrets section of your Github repo's settings. They should be called `WPENGINE_SSH_KEY_PUBLIC` and `WPENGINE_SSH_KEY_PRIVATE`. The same public key in `WPENGINE_SSH_KEY_PUBLIC` needs to be set inside inside the WP Engine environment in order to deploy.
+
+You'll also want to setup a Slack webhook URL and set it as the `SLACK_WEBHOOK` environment variable. You will get deployment updates for both success and failure.
+
+In our usage, we've found that a moderately complex site can deploy to WP Engine within 3-4 minutes of pushing code to Github.
+
 ## Based on Bubs
 
 This project is based on [Bubs](https://github.com/patronage/bubs-wp/) by [Patronage](http://www.patronage.org/studio).


### PR DESCRIPTION
Uses Github Actions to deploy site to WP Engine. JS and SCSS are built using gulp, and everything deploys as it would if you ran `sh _build/deploy.sh`

In order to setup, a SSH key needs to be created and the private & public keys need to be set inside the Secrets section of Github's settings. They should be called `WPENGINE_SSH_KEY_PUBLIC` and `WPENGINE_SSH_KEY_PRIVATE`. The same public key in `WPENGINE_SSH_KEY_PUBLIC` needs to be set inside inside the WP Engine environment in order to deploy.

You'll also want to setup a Slack webhook URL and set it as the `SLACK_WEBHOOK` environment variable.

In one of our sites, changes are deployed to WP Engine in under 3 minutes.

