### PR TITLE
118 new gulp adjusts

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -15,7 +15,8 @@ const stylish = require('jshint-stylish');
 
 // others
 import browserSync from 'browser-sync';
-const server = browserSync.create();
+browserSync.create();
+
 //
 // Gulp config
 //
@@ -210,27 +211,39 @@ export const clean = done => {
     done();
 }
 
-const serve = done => {
-    server.init({
-        proxy: localConfig.bs.proxy,
-        notify: localConfig.bs.notify || false,
-        open: localConfig.bs.open || true,
-        tunnel: localConfig.bs.tunnel || false,
-        logLevel: localConfig.bs.logLevel || 'info'
-    });
 
-    gulp.watch(config.theme + '/**/*.{twig,php}', reload);
-    gulp.watch(config.assets + '/scss/**/*.scss', styles);
-    gulp.watch(config.assets + '/js/**/*.js', gulp.series(scripts, reload));
-    gulp.watch(config.assets + '/{img,fonts}/**', gulp.series(copy, reload));
+gulp.task('browser-sync', function(){
 
-    done();
-}
+  browserSync.init({
+      proxy: localConfig.bs.proxy,
+      notify: localConfig.bs.notify || false,
+      open: localConfig.bs.open || true,
+      tunnel: localConfig.bs.tunnel || false,
+      logLevel: localConfig.bs.logLevel || 'info'
+  })
+})
+
+
+
 
 const reload = done => {
-    server.reload();
+    console.log("reloading");
+    browserSync.reload({stream: true});
     done();
 }
+
+//
+gulp.task('watch', gulp.parallel('browser-sync', function(done){
+  gulp.watch(config.assets + '/scss/**/*.scss', styles);
+
+
+  gulp.watch(config.theme + '/**/*.{twig,php}', reload);
+  gulp.watch(config.assets + '/js/**/*.js', gulp.series(scripts, reload));
+  gulp.watch(config.assets + '/{img,fonts}/**', gulp.series(copy, reload));
+
+  done();
+}));
+
 
 //gulp release
 export const release = done => {
@@ -241,6 +254,6 @@ export const release = done => {
 }
 
 const compile = gulp.series(clean, styles, scripts, copy, cleanScripts, rev, staticHeaders);
-export const defaultTasks = gulp.series(clean, styles, copy, serve);
+export const defaultTasks = gulp.series(clean, styles, copy, 'watch');
 
 export default defaultTasks;

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -21,19 +21,22 @@ const server = browserSync.create();
 //
 
 // Override defaults with custom local config
+var localConfig = {
+    bs: {
+        proxy: "www.bubs.loc",
+        logLevel: "info",
+        tunnel: "",
+        open: false,
+        notify: false
+    }
+};
 
+// If there's a gulpconfig.json file, it additively overrides any of those default localConfig options
 try {
-    var localConfig = require('./gulpconfig.json');
+    var localConfigFromConfig = require('./gulpconfig.json');
+    Object.assign(localConfig, localConfigFromConfig);
 } catch (err) {
-    var localConfig = {
-        bs: {
-            proxy: "www.bubs.loc",
-            logLevel: "info",
-            tunnel: "",
-            open: false,
-            notify: false
-        }
-    };
+    // didn't fine the file? no overriding done. use defaults
 }
 
 // Build themeDir variable based on current theme from config file, fallback to default

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gulp-autoprefixer": "^7.0.1",
     "gulp-babel": "^8.0.0",
     "gulp-csso": "^4.0.1",
+    "gulp-debug": "^4.0.0",
     "gulp-filter": "6.0.0",
     "gulp-if": "3.0.0",
     "gulp-jshint": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "gulp-notify": "^3.2.0",
     "gulp-rename": "2.0.0",
     "gulp-rev-all": "2.0.3",
-    "gulp-sass": "^4.0.2",
+    "gulp-sass": "^4.1.0",
     "gulp-uglify": "^3.0.2",
     "gulp-useref": "4.0.1",
     "husky": "^0.14.3",
     "jshint": "^2.11.0",
     "jshint-stylish": "^2.2.1",
-    "node-sass": "^4.13.1"
+    "node-sass": "^4.14.0"
   },
   "dependencies": {
     "@bower_components/fitvids": "davatron5000/fitvids.js#^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2577,6 +2577,11 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
+get-own-enumerable-property-symbols@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
+  integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -2786,6 +2791,18 @@ gulp-csso@^4.0.1:
     csso "^4.0.0"
     plugin-error "^1.0.0"
     vinyl-sourcemaps-apply "^0.2.1"
+
+gulp-debug@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-debug/-/gulp-debug-4.0.0.tgz#036f9539c3fb6af720e01a9ea5c195fc73f29d5b"
+  integrity sha512-cn/GhMD2nVZCVxAl5vWao4/dcoZ8wUJ8w3oqTvQaGDmC1vT7swNOEbhQTWJp+/otKePT64aENcqAQXDcdj5H1g==
+  dependencies:
+    chalk "^2.3.0"
+    fancy-log "^1.3.2"
+    plur "^3.0.0"
+    stringify-object "^3.0.0"
+    through2 "^2.0.0"
+    tildify "^1.1.2"
 
 gulp-filter@6.0.0:
   version "6.0.0"
@@ -3196,6 +3213,11 @@ irregular-plurals@^1.0.0:
   resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-1.4.0.tgz#2ca9b033651111855412f16be5d77c62a458a766"
   integrity sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=
 
+irregular-plurals@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-2.0.0.tgz#39d40f05b00f656d0b7fa471230dd3b714af2872"
+  integrity sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==
+
 is-absolute@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-absolute/-/is-absolute-1.0.0.tgz#395e1ae84b11f26ad1795e73c17378e48a301576"
@@ -3361,6 +3383,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
 is-path-cwd@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
@@ -3377,6 +3404,11 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
 is-relative@^1.0.0:
   version "1.0.0"
@@ -4563,6 +4595,13 @@ plur@^2.1.0:
   dependencies:
     irregular-plurals "^1.0.0"
 
+plur@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/plur/-/plur-3.1.1.tgz#60267967866a8d811504fe58f2faaba237546a5b"
+  integrity sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==
+  dependencies:
+    irregular-plurals "^2.0.0"
+
 popper.js@1.16.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
@@ -5498,6 +5537,15 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+stringify-object@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
+  dependencies:
+    get-own-enumerable-property-symbols "^3.0.0"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
+
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -5634,6 +5682,13 @@ through@2, through@^2.3.8, through@~2.3, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+tildify@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tildify/-/tildify-1.2.0.tgz#dcec03f55dca9b7aa3e5b04f21817eb56e63588a"
+  integrity sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=
+  dependencies:
+    os-homedir "^1.0.0"
 
 time-stamp@^1.0.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2876,13 +2876,13 @@ gulp-rev-all@2.0.3:
     through2 "^3.0.1"
     vinyl "^2.1.0"
 
-gulp-sass@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/gulp-sass/-/gulp-sass-4.0.2.tgz#cfb1e3eff2bd9852431c7ce87f43880807d8d505"
-  integrity sha512-q8psj4+aDrblJMMtRxihNBdovfzGrXJp1l4JU0Sz4b/Mhsi2DPrKFYCGDwjIWRENs04ELVHxdOJQ7Vs98OFohg==
+gulp-sass@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/gulp-sass/-/gulp-sass-4.1.0.tgz#486d7443c32d42bf31a6b1573ebbdaa361de7427"
+  integrity sha512-xIiwp9nkBLcJDpmYHbEHdoWZv+j+WtYaKD6Zil/67F3nrAaZtWYN5mDwerdo7EvcdBenSAj7Xb2hx2DqURLGdA==
   dependencies:
     chalk "^2.3.0"
-    lodash.clonedeep "^4.3.2"
+    lodash "^4.17.11"
     node-sass "^4.8.3"
     plugin-error "^1.0.1"
     replace-ext "^1.0.0"
@@ -3757,7 +3757,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@4.17.15, lodash@^4.0.0, lodash@^4.12.0, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.15, lodash@~4.17.11, lodash@~4.17.12:
+lodash@4.17.15, lodash@^4.0.0, lodash@^4.12.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@~4.17.11, lodash@~4.17.12:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -4065,7 +4065,30 @@ node-releases@^1.1.53:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
   integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
 
-node-sass@^4.13.1, node-sass@^4.8.3:
+node-sass@^4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.0.tgz#a8e9d7720f8e15b4a1072719dcf04006f5648eeb"
+  integrity sha512-AxqU+DFpk0lEz95sI6jO0hU0Rwyw7BXVEv6o9OItoXLyeygPeaSpiV4rwQb10JiTghHaa0gZeD21sz+OsQluaw==
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash "^4.17.15"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.13.2"
+    node-gyp "^3.8.0"
+    npmlog "^4.0.0"
+    request "^2.88.0"
+    sass-graph "^2.2.4"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
+
+node-sass@^4.8.3:
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
   integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==


### PR DESCRIPTION
This PR addresses some issues raised in PR #118 .  That is, provides changes from this branch `118-new-gulp-adjusts` for that PR's branch,  `new-gulp` (not `master`)

* It adjusts the gulpfile.babel.js file to fix the gulp watch. The scss change now correctly injects into the stream: 

![Peek 2020-05-03 21-26](https://user-images.githubusercontent.com/128731/80930962-f2fba900-8d84-11ea-9da9-03712f9172f7.gif)

It gives css its own reload function for streaming. The other tasks (like js) still use the standard reload as before.

This was tested with node v12.16.2 

* The gulpconfig.json override is now an additive one, rather than either/or. the json file still overrides the default values when present. It's just on a key by key case rather than all or nothing.

* Additionally we bump gulp-sass and node-sass to the latest stable versions (slight increase from already upgraded ones).

* Also added [gulp-debug](https://github.com/sindresorhus/gulp-debug) for future pipe debugging.We added one commented out sample usage, so it doesn't affect build time.

* Also have any errors in handleErrors display as well in the console, for extra visibility. 

In addition to scss, I also tested a trivial js change in main.js and the page reloaded correctly. I also tested  and gulp release and the `dist/` assets generate fine. 

@chrisherold , can you look this over and if it looks fine, merge?  (it will merge into the `gulp-new` branch from PR #118  . Otherwise questions/comments welcome. 

