### PR TITLE
Upgrade jQuery from 3.5.0 to 3.5.1 to fix broken collapse.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "bootstrap": "4.4.1",
         "cookies-js": "1.2.3",
         "fitvids.js": "davatron5000/fitvids.js#^1.2.0",
-        "jquery": "3.5.0",
+        "jquery": "3.5.1",
         "jquery-match-height": "0.7.2",
         "jquery-smooth-scroll": "2.2.0",
         "lodash": "4.17.15",


### PR DESCRIPTION
Discussed this one with @yuvilio after I noticed a broken responsive menu with a new bubs project. Clicking on the hamburger menu to expand/collapse a menu was causing a console error (and not expanding the menu): `TypeError: cannot convert object to primitive value`

@yuvilio found this issue in reference:
https://github.com/twbs/bootstrap/issues/30553 

Per this comment: https://github.com/twbs/bootstrap/issues/30553#issuecomment-623866824 bumping up jQuery from `3.5.0` to `3.5.1` solved the issue. Tested locally and confirmed.