### PR TITLE
gulp displays error message on terminal when available

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -61,6 +61,11 @@ let isProduction = false;
 // Error Handling
 
 const handleErrors = err => {
+
+    if (err.message){ // note the error on console as well
+        console.log(err.message);
+    }
+
     // special variables for uglify
     if (err.cause) {
         err.message = err.cause.message;


### PR DESCRIPTION
Make sure gulp displays scss/js error messages on the terminal when running. Example error:

```bash
[18:51:06] Starting 'styles'...
wp-content/themes/timber/assets/scss/components/_hero.scss
Error: Invalid CSS after "        color": expected "}", was ": $white;"
        on line 8 of wp-content/themes/timber/assets/scss/components/_hero.scss
        from line 37 of wp-content/themes/timber/assets/scss/screen.scss
>>         color: $white;

   --------^

[18:51:06] Finished 'styles' after 91 ms

```