### PR TITLE
composer setup + plugin upgrades derived from recent Quarter 3 upgrades

### DIFF
--- a/_init/init.sh
+++ b/_init/init.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
-rm -rf ./composer/wp-content/themes/twenty*
-rm -rf ./composer/wp-config-sample.php
-rm -rf ./composer/wp-content/plugins/hello.php
+# clear plugins to force new versions (excluding non-Wordpress plugin composer-libs/ )
+shopt -s extglob
+rm -rf ./wp-content/plugins/!(composer-libs)
+
+# Clean composer before copying . roots/wordpress installs the wordpress core into wp/ . Update wordpress
+rm -rf ./composer/wp/wp-config-sample.php
+rm -rf ./composer/wp/wp-content/
+mv -n ./composer/wp/* ./composer
+rm -rf ./composer/wp/
+
+
 cp -R ./composer/* ./
 
 cp -n _init/wp-config-sample.php wp-config.php 2>/dev/null || :

--- a/composer.json
+++ b/composer.json
@@ -1,99 +1,81 @@
 {
     "name": "patronage/bubs",
     "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
         "vendor-dir": "wp-content/plugins/composer-libs"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
-        "php": ">=7.3",
-        "wordpress/wordpress": "5.4.2",
-        "advanced-custom-fields/advanced-custom-fields-pro": "5.8.9",
+        "php": ">=7.4.0",
+        "composer/installers": "^1.8",
+        "advanced-custom-fields/advanced-custom-fields-pro": "5.9.1",
         "roots/soil": "3.9.0",
-        "upstatement/routes": "0.6.0",
+        "roots/wordpress": "5.5.1",
+        "upstatement/routes": "0.8.0",
         "wpackagist-plugin/acf-to-wp-api": "1.4.0",
         "wpackagist-plugin/airplane-mode": "0.2.5",
-        "wpackagist-plugin/bottom-admin-bar": "1.3",
-        "wpackagist-plugin/classic-editor": "1.5",
-        "wpackagist-plugin/debug-bar": "1.0.1",
-        "wpackagist-plugin/debug-bar-timber": "0.3",
+        "wpackagist-plugin/classic-editor":"1.6",
+        "wpackagist-plugin/debug-bar":"1.0.1",
+        "wpackagist-plugin/debug-bar-timber":"1.0.6",
         "wpackagist-plugin/disable-emojis": "1.7.2",
-        "wpackagist-plugin/duplicate-post": "3.2.4",
-        "wpackagist-plugin/enable-media-replace": "3.4.1",
+        "wpackagist-plugin/duplicate-post":"3.2.6",
+        "wpackagist-plugin/enable-media-replace":"3.4.2",
         "wpackagist-plugin/filter-page-by-template": "1.4",
         "wpackagist-plugin/google-apps-login": "3.4.2",
         "wpackagist-plugin/gutenberg-ramp": "1.1.0",
         "wpackagist-plugin/post-type-archive-links": "1.3.1",
         "wpackagist-plugin/post-type-switcher": "3.2.0",
-        "wpackagist-plugin/query-monitor": "3.6.0",
-        "wpackagist-plugin/quick-pagepost-redirect-plugin": "5.1.9",
+        "wpackagist-plugin/query-monitor":"3.6.4",
+        "wpackagist-plugin/redirection":"4.8",
         "wpackagist-plugin/term-management-tools": "1.1.4",
-        "wpackagist-plugin/timber-library": "1.16.0",
-        "wpackagist-plugin/transients-manager": "1.8",
-        "wpackagist-plugin/user-switching": "1.5.4",
-        "wpackagist-plugin/wordpress-seo": "14.3",
+        "wpackagist-plugin/timber-library":"1.18.1",
+        "wpackagist-plugin/transients-manager": "1.8.1",
+        "wpackagist-plugin/user-switching":"1.5.6",
+        "wpackagist-plugin/wordpress-seo": "15.0",
         "wpackagist-plugin/wp-api-yoast-meta": "1.2.0",
-        "wpackagist-plugin/wp-rest-api-v2-menus": "0.7.7"
+        "wpackagist-plugin/wp-rest-api-v2-menus":"0.8"
     },
     "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "wordpress/wordpress",
-                "type": "webroot",
-                "version": "5.4.2",
-                "dist": {
-                    "type": "zip",
-                    "url": "https://github.com/WordPress/WordPress/archive/5.4.2.zip"
-                },
-                "require": {
-                    "fancyguy/webroot-installer": "~1.1"
-                }
-            }
-        },
         {
             "type": "composer",
             "url": "https://wpackagist.org"
         },
         {
-            "type": "package",
-            "package": {
-                "name": "advanced-custom-fields/advanced-custom-fields-pro",
-                "version": "5.8.9",
-                "type": "wordpress-plugin",
-                "dist": {
-                    "type": "zip",
-                    "url": "https://www.dropbox.com/s/khivi7470f6wrtm/empty.zip?dl=1"
-                },
-                "autoload": {
-                    "psr-0": {
-                        "acf\\advanced-custom-fields-pro": ""
-                    }
-                },
-                "require": {
-                    "composer/installers": "1.9.0"
-                }
+          "type": "package",
+          "package": {
+            "name": "advanced-custom-fields/advanced-custom-fields-pro",
+            "version": "5.9.1",
+            "type": "wordpress-plugin",
+            "dist": {
+              "type": "zip",
+              "url": "https://connect.advancedcustomfields.com/index.php?a=download&p=pro&k={%PLUGIN_ACF_KEY}&t={%VERSION}"
+            },
+            "require": {
+              "ffraenz/private-composer-installer": "^4.0"
             }
-        }
+          }
+      }
     ],
     "extra": {
         "webroot-dir": "composer",
         "webroot-package": "wordpress/wordpress",
         "installer-paths": {
-            "composer/wp-content/mu-plugins/{$name}/": [
-                "type:wordpress-muplugin"
-            ],
-            "composer/wp-content/plugins/{$name}/": [
-                "type:wordpress-plugin"
-            ],
-            "composer/wp-content/themes/{$name}/": [
-                "type:wordpress-theme"
-            ]
-        }
+          "composer/wp-content/mu-plugins/{$name}/": [
+            "type:wordpress-muplugin"
+          ],
+          "composer/wp-content/plugins/{$name}/": [
+            "type:wordpress-plugin"
+          ],
+          "composer/wp-content/themes/{$name}/": [
+            "type:wordpress-theme"
+          ]
+        },
+        "wordpress-install-dir": "composer/wp"
     },
     "scripts": {
         "post-install-cmd": [
-            "bash ./_init/init.sh"
-        ],
-        "post-update-cmd": [
             "bash ./_init/init.sh"
         ]
     }

--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,9 @@
     "scripts": {
         "post-install-cmd": [
             "bash ./_init/init.sh"
+        ],
+        "post-update-cmd": [
+            "bash ./_init/init.sh"
         ]
     }
 }


### PR DESCRIPTION
This PR upgrades wordpress core/plugins including process adjusts in doing go:

This includes :


* Adding the composer/installers to top level rather than custom usage per package that needs it.
* Replacing the old ACF Pro installation setup with a more dynamic installer. It has a newer installer, no longer requires manual file setup (just pick the version number). When using either substitute the ACF Pro license key into the file. Or add it a `$PLUGIN_ACF_KEY` environment variable to your local environment.
* Using the more up to date roots/wordpress package for installing wordpress core (over the not updated fancyguy/webroot-installer). We adjusted the installer shell script to work with it.
* On install, we [now clear the wordpress plugin directory](https://github.com/patronage/bubs/blob/q32020-wp-upgrade/_init/init.sh#L5) (except for non-plugin composer-libs) as a sanity check. The thinking is to sanity check that old version and new version plugin files aren't ever mixed. You always get the updated plugin and only that.
* Misc plugin upgrades.

@chrisherold , one note. In composer.json, I removed the [post-update-cmd](https://github.com/patronage/bubs/blob/master/composer.json#L96-L98) init.sh entry in "scripts" because it makes `composer update`'s functionality overlap with composer install. I see update as just focused on prep of composer.lock and the build directory ( `composer/`) while `composer install` being the one that carries out the install to the root directory. init.sh seems to just contribute to the installation. Chime in if you think otherwise.


We've tested it on recent big clients and it looks good. I also just tested it on bubs local instance.




