### PR TITLE
Prevent local dev errors  to propagate to a live Administration Email…

### DIFF
--- a/_init/local.sql
+++ b/_init/local.sql
@@ -16,3 +16,6 @@
 ## Set local admin user login to: admin:password
 UPDATE `wp_users` SET `user_login` = 'admin', `user_nicename` = 'admin' WHERE `ID` = '1';
 UPDATE `wp_users` SET `user_pass` = '$P$BfuqvWHay8/zebob.mxuJvgSb.L0s4/' WHERE `ID` = '1';
+
+## Prevent local dev errors  to propagate to a live admin email account.
+UPDATE `wp_options` set `option_value` = 'dev@localhost.localdomain' where `option_name` = 'admin_email';


### PR DESCRIPTION
… Addres
![Screenshot_20220118_171641](https://user-images.githubusercontent.com/128731/150028098-ad78ef1e-bf0f-4739-9fc5-3306cf2179ea.png)

Wordpress and hosts have a built in notification triggered by some errors. It can send "Your Site is Experiencing a Technical Issue" notification emails to the client's associated Administration Email . 


This PR adjusts local.sql to change tht email to an inert local email address to prevent those emails from getting sent to the live one from the developer's mail server and not cause false alarms.